### PR TITLE
Update: "로그인 실패 문구 띄우기 세션 확인"

### DIFF
--- a/src/main/java/com/birdie/srm/controller/MemberController.java
+++ b/src/main/java/com/birdie/srm/controller/MemberController.java
@@ -1,9 +1,13 @@
 package com.birdie.srm.controller;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,12 +25,22 @@ public class MemberController {
 	@Autowired
 	private MemberService memberService;
 	
-	@GetMapping("/loginform") 
-	public String login(){
-		log.info("로그인");
-		return "member/loginForm";
+	@GetMapping("/loginform")
+	public String login(HttpServletRequest request, Model model) {
+	    log.info("로그인");
+
+	    // 세션에서 인증 예외 정보를 확인
+	    Exception exception = (Exception) request.getSession().getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
+	    if (exception != null && "Bad credentials".equals(exception.getMessage())) {
+	        // Model에 오류 메시지 추가
+	        model.addAttribute("loginError", "아이디 또는 비밀번호가 틀립니다.");
+	        // 세션에서 예외 정보 제거
+	        request.getSession().removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
+	    }
+
+	    return "member/loginForm";
 	}
-	
+
 	@GetMapping("/signupform") 
 	public String signupForm(){
 		log.info("회원가입 폼");

--- a/src/main/java/com/birdie/srm/security/AuthenticationFailureHandler.java
+++ b/src/main/java/com/birdie/srm/security/AuthenticationFailureHandler.java
@@ -16,7 +16,7 @@ public class AuthenticationFailureHandler extends SimpleUrlAuthenticationFailure
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 			AuthenticationException exception) throws IOException, ServletException {
-		// TODO Auto-generated method stub
+
 		log.info("로그인 실패");
 		setDefaultFailureUrl("/member/loginform");
 

--- a/src/main/java/com/birdie/srm/security/LogoutSuccessHandler.java
+++ b/src/main/java/com/birdie/srm/security/LogoutSuccessHandler.java
@@ -13,7 +13,6 @@ public class LogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler{
 	@Override
 	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
 			throws IOException, ServletException {
-		// TODO Auto-generated method stub
 		super.onLogoutSuccess(request, response, authentication);
 	}
 }

--- a/src/main/webapp/WEB-INF/views/member/loginForm.jsp
+++ b/src/main/webapp/WEB-INF/views/member/loginForm.jsp
@@ -8,20 +8,32 @@
 <head>
 <meta charset="UTF-8">
 <title>SRM</title>
+    <!-- jQuery -->
+    <script src="${pageContext.request.contextPath}/resources/jquery/jquery.min.js" defer></script>
 
-<link rel="stylesheet"href="${pageContext.request.contextPath}/resources/bootstrap/bootstrap.min.css" />
-<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
-<script src="${pageContext.request.contextPath}/resources/jquery/jquery.min.js" defer></script><script src="${pageContext.request.contextPath}/resources/bootstrap/bootstrap.min.js" defer></script>
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
-<link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/member/login.css" />
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
+	<!-- Custom CSS -->
+	<link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/member/login.css" />
 
 </head>
 <body>
 	<div class="login-container">
 		<span>SRM 시스템 로그인</span>
-
+		
+		<c:if test="${not empty loginError}">
+		    <div class="alert alert-danger mb-2" role="alert" style="width: 350px; text-align: center; margin: 0 auto;">
+		        ${loginError}
+		    </div>
+		</c:if>
+		
 		<form method="post" action="${pageContext.request.contextPath}/login">
 			<input id="mem-id" type="text" name="mem_id"
 				placeholder="ID를 입력해 주세요." required>


### PR DESCRIPTION
- **변경 사항**
   - 로그인 실패 시 잘못된 아이디/비밀번호 오류 메시지를 표시한 후, 페이지 새로 고침 시 해당 오류 메시지가 사라지도록 기능을 추가했습니다.
기존 RedirectAttributes 대신 Model을 사용하여 오류 메시지를 loginError 속성으로 전달하게 변경했습니다.
- **변경 이유**
   - 로그인 오류 메시지가 새로 고침 시에도 남아 있는 문제를 해결하기 위해 예외 정보를 세션에서 제거하는 로직을 추가했습니다.
- **적용 사항**
  - MemberController의 login 메서드에서 세션의 예외 정보를 확인하고 loginError 메시지를 Model로 전달하도록 수정
JSP 페이지에서 loginError 메시지를 조건부로 표시하도록 구현
- **기대 효과**
   - 로그인 실패 시 오류 메시지가 한 번만 표시되고, 페이지를 새로 고침해도 재출력되지 않도록 개선되었습니다.